### PR TITLE
Adds docker workflow to http_api template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,3 +40,22 @@ jobs:
           working-directory: "${{matrix.template}}_test/"
       - name: Tests
         run: "cd ${{matrix.template}}_test && make test"
+      - name: Check if Dockerfile exists
+        id: dockerfile-check
+        run: |
+          if [ -f "${{matrix.template}}_test/Dockerfile" ]; then
+            echo "dockerfile_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "dockerfile_exists=false" >> $GITHUB_OUTPUT
+          fi
+      - name: Set up Docker Buildx
+        if: steps.dockerfile-check.outputs.dockerfile_exists == 'true'
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+      - name: Build and push Docker image
+        if: steps.dockerfile-check.outputs.dockerfile_exists == 'true'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: ${{matrix.template}}_test
+          platforms: 'linux/amd64'
+          build-args: |
+            VERSION=dev

--- a/http_api/templates/.github/workflows/docker.yml
+++ b/http_api/templates/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Build Docker Image 
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: github.event_name != 'pull_request'
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
+        with:
+          images: ghcr.io/${{ github.repository }}
+      - name: Set VERSION based on trigger type
+        id: extract_version
+        run: |
+          if [[ $GITHUB_REF_TYPE == "tag" ]]; then
+            # For tag triggers, use the tag name
+            echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          else
+            # For branch/commit triggers, use the commit hash
+            echo "VERSION=${GITHUB_SHA}" >> $GITHUB_ENV
+          fi
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{  github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
+

--- a/http_api/templates/.github/workflows/docker.yml
+++ b/http_api/templates/.github/workflows/docker.yml
@@ -28,13 +28,13 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: {{"${{ github.actor }}"}}
+          password: {{"${{ secrets.GITHUB_TOKEN }}"}}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/{{"${{ github.repository }}"}}
       - name: Set VERSION based on trigger type
         id: extract_version
         run: |
@@ -49,10 +49,10 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{  github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          push: {{"${{ github.event_name != 'pull_request' }}"}}
+          tags: {{"${{ steps.meta.outputs.tags }}"}}
+          labels: {{"${{ steps.meta.outputs.labels }}"}}
+          platforms: {{"${{  github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}"}}
           build-args: |
-            VERSION=${{ env.VERSION }}
+            VERSION={{"${{ env.VERSION }}"}}
 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and publishing Docker images for the project. The workflow is triggered on pushes to the main branch, tags that start with "v", and pull requests. It ensures consistent Docker image builds and handles tagging based on the trigger type.

**CI/CD Automation:**

* Added a new workflow file (`.github/workflows/docker.yml`) that builds and pushes Docker images to GitHub Container Registry on pushes to main, version tags, and pull requests.
* The workflow sets up QEMU and Buildx for multi-platform builds, logs in to the container registry, and extracts metadata for tagging and labeling images.
* The Docker image version is set dynamically: it uses the tag name for tag triggers and the commit hash for branch/commit triggers.
* Images are pushed to the registry only for non-pull request events, and support both `linux/amd64` and `linux/arm64` platforms for main and tag builds.