### PR TITLE
chore: update action versions and extend Dependabot coverage to templates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,26 @@
-# Basic set up for three package managers
-
 version: 2
 updates:
 
-  # Maintain dependencies for GitHub Actions
+  # Maintain dependencies for GitHub Actions in root workflows
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: gomod
-    directory: "/"
+
+  # Maintain dependencies for GitHub Actions in http_api template
+  - package-ecosystem: "github-actions"
+    directory: "/http_api/templates"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for GitHub Actions in package template
+  - package-ecosystem: "github-actions"
+    directory: "/package/templates"
+    schedule:
+      interval: "weekly"
+
+  # Maintain dependencies for GitHub Actions in telegram_bot template
+  - package-ecosystem: "github-actions"
+    directory: "/telegram_bot/templates"
     schedule:
       interval: "weekly"

--- a/http_api/templates/.github/workflows/docker.yml
+++ b/http_api/templates/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
         if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392

--- a/http_api/templates/.github/workflows/tests.yml
+++ b/http_api/templates/.github/workflows/tests.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
       - name: Display Go version
         run: go version
       - name: Code Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/package/templates/.github/workflows/tests.yml
+++ b/package/templates/.github/workflows/tests.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
       - name: Display Go version
         run: go version
       - name: Code Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/telegram_bot/templates/.github/workflows/docker.yml
+++ b/telegram_bot/templates/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
         if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392

--- a/telegram_bot/templates/.github/workflows/tests.yml
+++ b/telegram_bot/templates/.github/workflows/tests.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.1'
       - name: Display Go version
         run: go version
       - name: Code Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
       - name: Build
         run: go build -v ./...
       - name: Test


### PR DESCRIPTION
## Summary

Updates GitHub Actions versions across all templates to match the root workflow, and fixes the Dependabot configuration to actually cover the template directories.

## Changes

### GitHub Actions bumped (all 3 templates: `http_api`, `package`, `telegram_bot`)

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-go` | `@v5` | `@v6` |
| `golangci/golangci-lint-action` | `4afd733a` | `82606bf2` |
| `actions/checkout` in `docker.yml` | `@v4` | `@v6` |

### `.github/dependabot.yml`

- **Removed** the broken `gomod` entry — it pointed to `/` which has no `go.mod`; all tracked `go.mod` files use Go template syntax (`{{ .Values.repo }}`) that Dependabot cannot parse
- **Added** `github-actions` Dependabot entries for all three template directories so action SHAs in templates will receive automatic update PRs going forward:
  - `/http_api/templates`
  - `/package/templates`
  - `/telegram_bot/templates`